### PR TITLE
Barrier Prior to AlltoAll

### DIFF
--- a/src/gravity/paris/HenryPeriodic.hpp
+++ b/src/gravity/paris/HenryPeriodic.hpp
@@ -121,7 +121,10 @@ void HenryPeriodic::filter(const size_t bytes, double *const before, double *con
         const int ib = k + dk * (jj + dj * ii);
         a[ia]        = b[ib];
       });
-
+  CHECK(cudaDeviceSynchronize());
+  
+  MPI_Barrier(MPI_COMM_WORLD);
+  
   // Redistribute into Z pencils
 
   const int countK = dip * djq * dk;
@@ -130,7 +133,6 @@ void HenryPeriodic::filter(const size_t bytes, double *const before, double *con
   MPI_Alltoall(ha_, countK, MPI_DOUBLE, hb_, countK, MPI_DOUBLE, commK_);
   CHECK(cudaMemcpy(b, hb_, bytes, cudaMemcpyHostToDevice));
   #else
-  CHECK(cudaDeviceSynchronize());
   MPI_Alltoall(a, countK, MPI_DOUBLE, b, countK, MPI_DOUBLE, commK_);
   #endif
 
@@ -170,6 +172,9 @@ void HenryPeriodic::filter(const size_t bytes, double *const before, double *con
           }
         });
   }
+  CHECK(cudaDeviceSynchronize());
+  
+  MPI_Barrier(MPI_COMM_WORLD);
 
   // Redistribute for Y pencils
   const int countJ = 2 * dip * djq * dhq;
@@ -178,7 +183,6 @@ void HenryPeriodic::filter(const size_t bytes, double *const before, double *con
   MPI_Alltoall(ha_, countJ, MPI_DOUBLE, hb_, countJ, MPI_DOUBLE, commJ_);
   CHECK(cudaMemcpy(b, hb_, bytes, cudaMemcpyHostToDevice));
   #else
-  CHECK(cudaDeviceSynchronize());
   MPI_Alltoall(a, countJ, MPI_DOUBLE, b, countJ, MPI_DOUBLE, commJ_);
   #endif
 
@@ -219,6 +223,9 @@ void HenryPeriodic::filter(const size_t bytes, double *const before, double *con
           }
         });
   }
+  CHECK(cudaDeviceSynchronize());
+  
+  MPI_Barrier(MPI_COMM_WORLD);
 
   // Redistribute for X pencils
   const int countI = 2 * dip * djp * dhq;
@@ -227,7 +234,6 @@ void HenryPeriodic::filter(const size_t bytes, double *const before, double *con
   MPI_Alltoall(ha_, countI, MPI_DOUBLE, hb_, countI, MPI_DOUBLE, commI_);
   CHECK(cudaMemcpy(b, hb_, bytes, cudaMemcpyHostToDevice));
   #else
-  CHECK(cudaDeviceSynchronize());
   MPI_Alltoall(a, countI, MPI_DOUBLE, b, countI, MPI_DOUBLE, commI_);
   #endif
 
@@ -287,6 +293,9 @@ void HenryPeriodic::filter(const size_t bytes, double *const before, double *con
           }
         });
   }
+  CHECK(cudaDeviceSynchronize());
+  
+  MPI_Barrier(MPI_COMM_WORLD);
 
   // Redistribute for Y pencils
   #ifndef MPI_GPU
@@ -294,7 +303,6 @@ void HenryPeriodic::filter(const size_t bytes, double *const before, double *con
   MPI_Alltoall(ha_, countI, MPI_DOUBLE, hb_, countI, MPI_DOUBLE, commI_);
   CHECK(cudaMemcpy(b, hb_, bytes, cudaMemcpyHostToDevice));
   #else
-  CHECK(cudaDeviceSynchronize());
   MPI_Alltoall(a, countI, MPI_DOUBLE, b, countI, MPI_DOUBLE, commI_);
   #endif
 
@@ -335,6 +343,9 @@ void HenryPeriodic::filter(const size_t bytes, double *const before, double *con
           }
         });
   }
+  CHECK(cudaDeviceSynchronize());
+  
+  MPI_Barrier(MPI_COMM_WORLD);
 
   // Redistribute in Z pencils
   #ifndef MPI_GPU
@@ -342,7 +353,6 @@ void HenryPeriodic::filter(const size_t bytes, double *const before, double *con
   MPI_Alltoall(ha_, countJ, MPI_DOUBLE, hb_, countJ, MPI_DOUBLE, commJ_);
   CHECK(cudaMemcpy(b, hb_, bytes, cudaMemcpyHostToDevice));
   #else
-  CHECK(cudaDeviceSynchronize());
   MPI_Alltoall(a, countJ, MPI_DOUBLE, b, countJ, MPI_DOUBLE, commJ_);
   #endif
 
@@ -382,6 +392,9 @@ void HenryPeriodic::filter(const size_t bytes, double *const before, double *con
           }
         });
   }
+  CHECK(cudaDeviceSynchronize());
+  
+  MPI_Barrier(MPI_COMM_WORLD);
 
   // Redistribute for 3D blocks
   #ifndef MPI_GPU
@@ -389,7 +402,7 @@ void HenryPeriodic::filter(const size_t bytes, double *const before, double *con
   MPI_Alltoall(ha_, countK, MPI_DOUBLE, hb_, countK, MPI_DOUBLE, commK_);
   CHECK(cudaMemcpy(b, hb_, bytes, cudaMemcpyHostToDevice));
   #else
-  CHECK(cudaDeviceSynchronize());
+  
   MPI_Alltoall(a, countK, MPI_DOUBLE, b, countK, MPI_DOUBLE, commK_);
   #endif
 

--- a/src/gravity/paris/PoissonZero3DBlockedGPU.cu
+++ b/src/gravity/paris/PoissonZero3DBlockedGPU.cu
@@ -166,12 +166,15 @@ void PoissonZero3DBlockedGPU::solve(const long bytes, double *const density, dou
           ua[(((p * mq + q) * dip + i) * djq + j) * dk + k] = ub[((i + iLo) * dj + j + jLo) * dk + k];
         }
       });
+  CHECK(cudaDeviceSynchronize());
+  
+  MPI_Barrier(MPI_COMM_WORLD);
+  
   #ifndef MPI_GPU
   CHECK(cudaMemcpy(ha_, ua, bytes_, cudaMemcpyDeviceToHost));
   MPI_Alltoall(ha_, dip * djq * dk, MPI_DOUBLE, hb_, dip * djq * dk, MPI_DOUBLE, commK_);
   CHECK(cudaMemcpyAsync(ub, hb_, bytes_, cudaMemcpyHostToDevice, 0));
   #else
-  CHECK(cudaDeviceSynchronize());
   MPI_Alltoall(ua, dip * djq * dk, MPI_DOUBLE, ub, dip * djq * dk, MPI_DOUBLE, commK_);
   #endif
   gpuFor(
@@ -217,12 +220,15 @@ void PoissonZero3DBlockedGPU::solve(const long bytes, double *const density, dou
           ua[((qb * dip + i) * dkq + kb) * djq + j] = wb * ak - wa * bk;
         }
       });
+  CHECK(cudaDeviceSynchronize());  
+  
+  MPI_Barrier(MPI_COMM_WORLD);
+    
   #ifndef MPI_GPU
   CHECK(cudaMemcpy(ha_, ua, bytes_, cudaMemcpyDeviceToHost));
   MPI_Alltoall(ha_, dip * dkq * djq, MPI_DOUBLE, hb_, dip * dkq * djq, MPI_DOUBLE, commJ_);
   CHECK(cudaMemcpyAsync(ub, hb_, bytes_, cudaMemcpyHostToDevice, 0));
   #else
-  CHECK(cudaDeviceSynchronize());
   MPI_Alltoall(ua, dip * dkq * djq, MPI_DOUBLE, ub, dip * dkq * djq, MPI_DOUBLE, commJ_);
   #endif
   gpuFor(
@@ -267,12 +273,15 @@ void PoissonZero3DBlockedGPU::solve(const long bytes, double *const density, dou
           ua[((pb * dkq + k) * djp + jb) * dip + i] = wb * aj - wa * bj;
         }
       });
+  CHECK(cudaDeviceSynchronize());
+  
+  MPI_Barrier(MPI_COMM_WORLD);
+  
   #ifndef MPI_GPU
   CHECK(cudaMemcpy(ha_, ua, bytes_, cudaMemcpyDeviceToHost));
   MPI_Alltoall(ha_, dkq * djp * dip, MPI_DOUBLE, hb_, dkq * djp * dip, MPI_DOUBLE, commI_);
   CHECK(cudaMemcpyAsync(ub, hb_, bytes_, cudaMemcpyHostToDevice, 0));
   #else
-  CHECK(cudaDeviceSynchronize());
   MPI_Alltoall(ua, dkq * djp * dip, MPI_DOUBLE, ub, dkq * djp * dip, MPI_DOUBLE, commI_);
   #endif
   gpuFor(
@@ -389,12 +398,15 @@ void PoissonZero3DBlockedGPU::solve(const long bytes, double *const density, dou
           ua[(((idb * mp + pb) * dkq + k) * dip + ib) * djp + j] = ai + bi;
         }
       });
+  CHECK(cudaDeviceSynchronize());
+  
+  MPI_Barrier(MPI_COMM_WORLD);
+  
   #ifndef MPI_GPU
   CHECK(cudaMemcpy(ha_, ua, bytes_, cudaMemcpyDeviceToHost));
   MPI_Alltoall(ha_, dkq * djp * dip, MPI_DOUBLE, hb_, dkq * djp * dip, MPI_DOUBLE, commI_);
   CHECK(cudaMemcpyAsync(ub, hb_, bytes_, cudaMemcpyHostToDevice, 0));
   #else
-  CHECK(cudaDeviceSynchronize());
   MPI_Alltoall(ua, dkq * djp * dip, MPI_DOUBLE, ub, dkq * djp * dip, MPI_DOUBLE, commI_);
   #endif
   gpuFor(
@@ -447,12 +459,15 @@ void PoissonZero3DBlockedGPU::solve(const long bytes, double *const density, dou
           ua[(((idb * mq + qb) * dip + i) * djq + jb) * dkq + k] = aj + bj;
         }
       });
+  CHECK(cudaDeviceSynchronize());
+  
+  MPI_Barrier(MPI_COMM_WORLD);
+  
   #ifndef MPI_GPU
   CHECK(cudaMemcpy(ha_, ua, bytes_, cudaMemcpyDeviceToHost));
   MPI_Alltoall(ha_, dip * djq * dkq, MPI_DOUBLE, hb_, dip * djq * dkq, MPI_DOUBLE, commJ_);
   CHECK(cudaMemcpyAsync(ub, hb_, bytes_, cudaMemcpyHostToDevice, 0));
   #else
-  CHECK(cudaDeviceSynchronize());
   MPI_Alltoall(ua, dip * djq * dkq, MPI_DOUBLE, ub, dip * djq * dkq, MPI_DOUBLE, commJ_);
   #endif
   gpuFor(
@@ -503,12 +518,15 @@ void PoissonZero3DBlockedGPU::solve(const long bytes, double *const density, dou
           ua[((pqb * dip + i) * djq + j) * dk + kb] = divN * (ak + bk);
         }
       });
+  CHECK(cudaDeviceSynchronize());
+  
+  MPI_Barrier(MPI_COMM_WORLD);
+  
   #ifndef MPI_GPU
   CHECK(cudaMemcpy(ha_, ua, bytes_, cudaMemcpyDeviceToHost));
   MPI_Alltoall(ha_, dip * djq * dk, MPI_DOUBLE, hb_, dip * djq * dk, MPI_DOUBLE, commK_);
   CHECK(cudaMemcpyAsync(ub, hb_, bytes_, cudaMemcpyHostToDevice, 0));
   #else
-  CHECK(cudaDeviceSynchronize());
   MPI_Alltoall(ua, dip * djq * dk, MPI_DOUBLE, ub, dip * djq * dk, MPI_DOUBLE, commK_);
   #endif
   gpuFor(


### PR DESCRIPTION
Adding MPI_Barrier() prior to AllToAll calls to improve gravity solver performance. Rearrange call to deviceSynchronize().